### PR TITLE
Explicitly set socket domain to ipv4

### DIFF
--- a/step/06-gateway-service/files/config_ws_tcp.conf
+++ b/step/06-gateway-service/files/config_ws_tcp.conf
@@ -4,3 +4,4 @@ listener 1883
 # this will expect websockets connections
 listener 9001
 protocol websockets
+socket_domain ipv4


### PR DESCRIPTION
Needed for the internal mqtt broker