### PR TITLE
Add back allow_anonymous to true in our config

### DIFF
--- a/step/06-gateway-service/files/config_ws_tcp.conf
+++ b/step/06-gateway-service/files/config_ws_tcp.conf
@@ -5,3 +5,5 @@ listener 1883
 listener 9001
 protocol websockets
 socket_domain ipv4
+
+allow_anonymous true


### PR DESCRIPTION
The default was true before, but changed in mosquitto 2+ (that is the case of bullseye)